### PR TITLE
clean up

### DIFF
--- a/.github/workflows/pushMasterCi.yml
+++ b/.github/workflows/pushMasterCi.yml
@@ -53,7 +53,7 @@ jobs:
       - name: write .env file
         run: |
           echo ${{ secrets.ENV_FILE_PROD }} | base64 -d > tc-api/.env
-          export SENTRYREL=SENTRY_VERSION=that-api-events@$(cat tc-api/package.json | jq '.version' | tr -d '"').$(echo $GITHUB_SHA | cut -c1-7)
+          SENTRYREL=SENTRY_VERSION=that-api-events@$(cat tc-api/package.json | jq '.version' | tr -d '"').$(echo $GITHUB_SHA | cut -c1-7)
           echo $SENTRYREL >> tc-api/.env
           echo "::set-env name=SENTRYREL::$SENTRYREL"
       - name: Checks and verifications


### PR DESCRIPTION
`echo "::set-env name=SENTRYREL::$SENTRYREL"`
Uses 'development tools for GitHub actions'
https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#set-an-environment-variable-set-env

This example sets the environment variable SENTRYREL for use in the rest of the steps within the current job. 