### PR TITLE
Fix bug where slack hook fired even unauthorized

### DIFF
--- a/src/graphql/resolvers/queries/communities.js
+++ b/src/graphql/resolvers/queries/communities.js
@@ -64,9 +64,10 @@ export const fieldResolvers = {
     sendDigest: async (
       { name },
       { hours, start },
-      { dataSources: { firestore } },
+      { dataSources: { firestore }, user },
     ) => {
       dlog('sendDialog called for %s, hours: %s', name, hours);
+      if (!user) return null;
       if (!hours) throw new Error('hours parameter required');
       if (hours < 1) throw new Error('hours minimum value is 1');
       if (hours > 168) throw new Error('hours maximum value is 168');


### PR DESCRIPTION
Fix for discovered bug where slack hook would still be called even with an unauthorized request. No data was returned from GraphQL as it failed unauthorized, but the resolver still ran which included the call to trigger the slack hook.