### PR TITLE
corrects hours after bug, where 61 total minutes were being added

### DIFF
--- a/src/dataSources/cloudFirestore/session.js
+++ b/src/dataSources/cloudFirestore/session.js
@@ -77,7 +77,12 @@ const session = dbInstance => {
 
       if (hoursAfter && hoursAfter > 0) {
         // 60 * 60 * 1000 = 3,600,000
-        const todate = new Date(fromdate.getTime() + hoursAfter * 3600000);
+        // -60000 to remove one minute, because:
+        // 1:00 to 2:00 is 61 total minutes
+        // 1:00 to 1:59 is 60 total minutes
+        const todate = new Date(
+          fromdate.getTime() + (hoursAfter * 3600000 - 60000),
+        );
         dlog('todate', todate);
         query = query.where('startTime', '<=', todate);
       }


### PR DESCRIPTION
Fixes issue where time span was adding 61 total minutes.

for example:
1:00 to 2:00 is 61 total minutes
where
1:00 to 1:59 is 60 total minutes which is what we want. 

The bug caused, when a time span of sessions from 1:00 for the next hour to also include any sessions set at 2:00 as well. Which is incorrect. 