### PR TITLE
Fixes unknown type issue on ProductBase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "that-api-events",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "that-api-events",
-      "version": "2.12.0",
+      "version": "2.13.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@apollo/federation": "0.22.0",
@@ -29,7 +29,7 @@
         "graphql-scalars": "^1.14.1",
         "graphql-type-json": "^0.3.2",
         "lodash": "^4.17.21",
-        "node-fetch": "^2.6.6",
+        "node-fetch": "^2.6.7",
         "postmark": "^2.8.1",
         "response-time": "^2.3.2",
         "slugify": "^1.6.5",
@@ -1996,27 +1996,27 @@
       }
     },
     "node_modules/@firebase/app": {
-      "version": "0.7.11",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.11.tgz",
-      "integrity": "sha512-GnG2XxlMrqd8zRa14Y3gvkPpr0tKTLZtxhUnShWkeSM5bQqk1DK2k9qDsf6D3cYfKCWv+JIg1zmL3oalxfhNNA==",
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.15.tgz",
+      "integrity": "sha512-jZzopQ5rKC3QcivZ9tBsYjPWB0+d5+lSO4tASIgAia30pyACCFaN2M1PKX/lwoGmB+oklHzSIMu+iNtLUyDl2A==",
       "peer": true,
       "dependencies": {
-        "@firebase/component": "0.5.9",
+        "@firebase/component": "0.5.10",
         "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.4.2",
+        "@firebase/util": "1.4.3",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.12.tgz",
-      "integrity": "sha512-hRzCCFjwTwrFsAFcuUW2TPpyShJ/OaoA1Yxp4QJr6Xod8g+CQxTMZ4RJ51I5t9fErXvl65VxljhfqFEyB3ZmJA==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.16.tgz",
+      "integrity": "sha512-PCGqanykO1H2jO3gzT0x7VxjZ0stBkF89VBqpOJfZ+srjSQgfWZuHjwbaVoq2Ayza1/s79iF0Eg7LSBx54TBSg==",
       "peer": true,
       "dependencies": {
-        "@firebase/app": "0.7.11",
-        "@firebase/component": "0.5.9",
+        "@firebase/app": "0.7.15",
+        "@firebase/component": "0.5.10",
         "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.4.2",
+        "@firebase/util": "1.4.3",
         "tslib": "^2.1.0"
       }
     },
@@ -2047,11 +2047,11 @@
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.9.tgz",
-      "integrity": "sha512-oLCY3x9WbM5rn06qmUvbtJuPj4dIw/C9T4Th52IiHF5tiCRC5k6YthvhfUVcTwfoUhK0fOgtwuKJKA/LpCPjgA==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.10.tgz",
+      "integrity": "sha512-mzUpg6rsBbdQJvAdu1rNWabU3O7qdd+B+/ubE1b+pTbBKfw5ySRpRRE6sKcZ/oQuwLh0HHB6FRJHcylmI7jDzA==",
       "dependencies": {
-        "@firebase/util": "1.4.2",
+        "@firebase/util": "1.4.3",
         "tslib": "^2.1.0"
       }
     },
@@ -2061,41 +2061,32 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@firebase/database": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.12.4.tgz",
-      "integrity": "sha512-XkrL1kXELRNkqKcltuT4hfG1gWmFiGvjFY+z7Lhb//12MqdkLjwa9YMK8c6Lo+Ro+IkWcJArQaOQYe3GkU5Wgg==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.12.5.tgz",
+      "integrity": "sha512-1Pd2jYqvqZI7SQWAiXbTZxmsOa29PyOaPiUtr8pkLSfLp4AeyMBegYAXCLYLW6BNhKn3zNKFkxYDxYHq4q+Ixg==",
       "dependencies": {
         "@firebase/auth-interop-types": "0.1.6",
-        "@firebase/component": "0.5.9",
+        "@firebase/component": "0.5.10",
         "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.4.2",
+        "@firebase/util": "1.4.3",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.1.4.tgz",
-      "integrity": "sha512-dIJiZLDFF3U+MoEwoPBy7zxWmBUro1KefmwSHlpOoxmPv76tuoPm85NumpW/HmMrtTcTkC2qowtb6NjGE8X7mw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.1.5.tgz",
+      "integrity": "sha512-UVxkHL24sZfsjsjs+yiKIdYdrWXHrLxSFCYNdwNXDlTkAc0CWP9AAY3feLhBVpUKk+4Cj0I4sGnyIm2C1ltAYg==",
       "dependencies": {
-        "@firebase/component": "0.5.9",
-        "@firebase/database": "0.12.4",
-        "@firebase/database-types": "0.9.3",
+        "@firebase/component": "0.5.10",
+        "@firebase/database": "0.12.5",
+        "@firebase/database-types": "0.9.4",
         "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.4.2",
+        "@firebase/util": "1.4.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
-      }
-    },
-    "node_modules/@firebase/database-compat/node_modules/@firebase/database-types": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.3.tgz",
-      "integrity": "sha512-R+YXLWy/Q7mNUxiUYiMboTwvVoprrgfyvf1Viyevskw6IoH1q8HV1UjlkLSgmRsOT9HPWt7XZUEStVZJFknHwg==",
-      "dependencies": {
-        "@firebase/app-types": "0.7.0",
-        "@firebase/util": "1.4.2"
       }
     },
     "node_modules/@firebase/database-compat/node_modules/tslib": {
@@ -2104,17 +2095,13 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@firebase/database-types": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.3.tgz",
-      "integrity": "sha512-dSOJmhKQ0nL8O4EQMRNGpSExWCXeHtH57gGg0BfNAdWcKhC8/4Y+qfKLfWXzyHvrSecpLmO0SmAi/iK2D5fp5A==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.4.tgz",
+      "integrity": "sha512-uAQuc6NUZ5Oh/cWZPeMValtcZ+4L1stgKOeYvz7mLn8+s03tnCDL2N47OLCHdntktVkhImQTwGNARgqhIhtNeA==",
       "dependencies": {
-        "@firebase/app-types": "0.6.3"
+        "@firebase/app-types": "0.7.0",
+        "@firebase/util": "1.4.3"
       }
-    },
-    "node_modules/@firebase/database-types/node_modules/@firebase/app-types": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.3.tgz",
-      "integrity": "sha512-/M13DPPati7FQHEQ9Minjk1HGLm/4K4gs9bR4rzLCWJg64yGtVC0zNg9gDpkw9yc2cvol/mNFxqTtd4geGrwdw=="
     },
     "node_modules/@firebase/database/node_modules/tslib": {
       "version": "2.3.1",
@@ -2135,9 +2122,9 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@firebase/util": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.4.2.tgz",
-      "integrity": "sha512-JMiUo+9QE9lMBvEtBjqsOFdmJgObFvi7OL1A0uFGwTmlCI1ZeNPOEBrwXkgTOelVCdiMO15mAebtEyxFuQ6FsA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.4.3.tgz",
+      "integrity": "sha512-gQJl6r0a+MElLQEyU8Dx0kkC2coPj67f/zKZrGR7z7WpLgVanhaCUqEsptwpwoxi9RMFIaebleG+C9xxoARq+Q==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -2210,45 +2197,36 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.16.1.tgz",
-      "integrity": "sha512-C2li/2PUfLSGEetebLL70uQRwqm6PS+kBtFEjr5AnAn/Qv0UnD8V+rI9Y4RmwxWFvhlPAgg+ZRqa4bkK4eUxlA==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.18.1.tgz",
+      "integrity": "sha512-EeVIarDb6u9vE5Se3YaXA8tuW8Ae2xmYLHy43doutTwzkXwizGXVS2Qmc2pouq9ln8qMD9A2f3arvhgAPtK9LQ==",
       "optional": true,
       "dependencies": {
         "@google-cloud/common": "^3.8.1",
         "@google-cloud/paginator": "^3.0.0",
         "@google-cloud/promisify": "^2.0.0",
+        "abort-controller": "^3.0.0",
         "arrify": "^2.0.0",
-        "async-retry": "^1.3.1",
+        "async-retry": "^1.3.3",
         "compressible": "^2.0.12",
+        "configstore": "^5.0.0",
         "date-and-time": "^2.0.0",
         "duplexify": "^4.0.0",
         "extend": "^3.0.2",
-        "gcs-resumable-upload": "^3.6.0",
+        "gaxios": "^4.0.0",
         "get-stream": "^6.0.0",
+        "google-auth-library": "^7.0.0",
         "hash-stream-validation": "^0.2.2",
         "mime": "^3.0.0",
         "mime-types": "^2.0.8",
         "p-limit": "^3.0.1",
         "pumpify": "^2.0.0",
         "snakeize": "^0.1.0",
-        "stream-events": "^1.0.1",
+        "stream-events": "^1.0.4",
         "xdg-basedir": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@google-cloud/storage/node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "optional": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@google-cloud/storage/node_modules/p-limit": {
@@ -3191,20 +3169,20 @@
       }
     },
     "node_modules/@thatconference/api": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-2.5.0.tgz",
-      "integrity": "sha512-QS8/91FMxT71q9HJyvFRz1ItZsaU3Mpk9XFp14c3d3KQwnRdx50jCzi0/E2txXU6mywglwZCmN2Flh9Su7NbBQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-2.7.0.tgz",
+      "integrity": "sha512-mLmgyY/m5LwG+cUKssM9DwDlDU5V/6VR9jQ5Rr9uSRhodA2JWHCC3a3yyv6g2b+nV4yG0/rnVtHzSAKXSuta4g==",
       "dependencies": {
         "apollo-server": "2.22.2",
-        "auth0": "^2.37.0",
+        "auth0": "^2.38.1",
         "debug": "^4.3.3",
-        "firebase-admin": "^10.0.1",
+        "firebase-admin": "^10.0.2",
         "graphql": "^15.8.0",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.5",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "node-fetch": "^2.6.6",
+        "node-fetch": "^2.6.7",
         "request-ip": "^2.1.3",
         "yup": "^0.32.11"
       },
@@ -4355,18 +4333,20 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/auth0": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.37.0.tgz",
-      "integrity": "sha512-6Kz/+7d3PRb1zKR6O7CVt0EHAu+dphLFbJcvCEn7z9mUyjM0kJp/RnkALfFLfVzmSsaWeBqQNi2uZmdjReCjzQ==",
+      "version": "2.38.1",
+      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.38.1.tgz",
+      "integrity": "sha512-46PS8bQyEJs7OAdhFAJKrgjCblovTij4hO7Y3PPPY2e8AulO8fGrvKDiucBLm2phGc8d45bOF7z7wB3ilNSc+A==",
       "dependencies": {
-        "axios": "^0.21.4",
-        "es6-promisify": "^6.1.1",
+        "axios": "^0.24.0",
         "form-data": "^3.0.1",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^1.12.1",
         "lru-memoizer": "^2.1.4",
-        "rest-facade": "^1.13.1",
+        "rest-facade": "^1.16.3",
         "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
       }
     },
     "node_modules/auth0/node_modules/jwks-rsa": {
@@ -4386,12 +4366,20 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/axios": {
+    "node_modules/auth0/node_modules/jwks-rsa/node_modules/axios": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
       "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
         "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/babel-eslint": {
@@ -5660,9 +5648,9 @@
       "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
     },
     "node_modules/date-and-time": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-2.0.1.tgz",
-      "integrity": "sha512-O7Xe5dLaqvY/aF/MFWArsAM1J4j7w1CSZlPCX9uHgmb+6SbkPd8Q4YOvfvH/cZGvFlJFfHOZKxQtmMUOoZhc/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-2.1.0.tgz",
+      "integrity": "sha512-X/b2gM7e8zQ7siiE0DhRLeNMpuCkIqec5Jnx4GMk/HWB71a6e5Lz48mH9/GIS/hpLsBRFZfMF1gjXBkY0vq5oA==",
       "optional": true
     },
     "node_modules/date-fns": {
@@ -6044,11 +6032,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es6-promisify": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -7149,17 +7132,17 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.0.1.tgz",
-      "integrity": "sha512-p8nrhNJyuAj/Pc3M0TWVU8rd4rPoeCREfRt7dJ+EwkMvFCdJ6Cb21y3ZlN3Qsbok8PEQjuWLNy+C3LQMTfUOcQ==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.0.2.tgz",
+      "integrity": "sha512-MLH0SPmC4L0aCHvPjs1KThraru/T84T3hxiPY3uCH7NZEgE/T5n4GwecwU3RcM3X+br75BIBY7qhaR5uCxhdXA==",
       "dependencies": {
         "@firebase/database-compat": "^0.1.1",
-        "@firebase/database-types": "^0.7.2",
+        "@firebase/database-types": "^0.9.3",
         "@types/node": ">=12.12.47",
         "dicer": "^0.3.0",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.2",
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.0.0"
       },
       "engines": {
         "node": ">=12.7.0"
@@ -7204,9 +7187,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "funding": [
         {
           "type": "individual",
@@ -7334,28 +7317,6 @@
       "dependencies": {
         "gaxios": "^4.0.0",
         "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gcs-resumable-upload": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.6.0.tgz",
-      "integrity": "sha512-IyaNs4tx3Mp2UKn0CltRUiW/ZXYFlBNuK/V+ixs80chzVD+BJq3+8bfiganATFfCoMluAjokF9EswNJdVuOs8A==",
-      "optional": true,
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "async-retry": "^1.3.3",
-        "configstore": "^5.0.0",
-        "extend": "^3.0.2",
-        "gaxios": "^4.0.0",
-        "google-auth-library": "^7.0.0",
-        "pumpify": "^2.0.0",
-        "stream-events": "^1.0.4"
-      },
-      "bin": {
-        "gcs-upload": "build/src/cli.js"
       },
       "engines": {
         "node": ">=10"
@@ -7553,11 +7514,11 @@
       }
     },
     "node_modules/google-p12-pem": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.2.tgz",
-      "integrity": "sha512-tjf3IQIt7tWCDsa0ofDQ1qqSCNzahXDxdAGJDbruWqu3eCg5CKLYKN+hi0s6lfvzYZ1GDVr+oDF9OOWlDSdf0A==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.3.tgz",
+      "integrity": "sha512-MC0jISvzymxePDVembypNefkAQp+DRP7dBE+zNUPaIjEspIlYg0++OrsNr248V9tPbz6iqtZ7rX1hxWA5B8qBQ==",
       "dependencies": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.0.0"
       },
       "bin": {
         "gp12-pem": "build/src/bin/gp12-pem.js"
@@ -10496,14 +10457,15 @@
       }
     },
     "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "optional": true,
       "bin": {
         "mime": "cli.js"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -10651,14 +10613,22 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-fetch/node_modules/tr46": {
@@ -10681,11 +10651,11 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-int64": {
@@ -11239,14 +11209,6 @@
       "integrity": "sha512-0rpIqBQ9ey7MqLVBlEJAnnw8lbnANqgnwR/lrXEzzdH1RggmTP/zAdZB9OEzgILK+Uw2FpIVyJrnhMimfjWMRQ==",
       "dependencies": {
         "axios": "^0.24.0"
-      }
-    },
-    "node_modules/postmark/node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/prelude-ls": {
@@ -13155,6 +13117,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.3.1.tgz",
       "integrity": "sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==",
+      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>. Thanks to @shadowgate15, @spence-s, and @niftylettuce. Superagent is sponsored by Forward Email at <https://forwardemail.net>.",
       "dependencies": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.2",
@@ -13172,10 +13135,21 @@
         "node": ">= 7.0.0"
       }
     },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/superagent/node_modules/qs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -15719,14 +15693,14 @@
       }
     },
     "@firebase/app": {
-      "version": "0.7.11",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.11.tgz",
-      "integrity": "sha512-GnG2XxlMrqd8zRa14Y3gvkPpr0tKTLZtxhUnShWkeSM5bQqk1DK2k9qDsf6D3cYfKCWv+JIg1zmL3oalxfhNNA==",
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.15.tgz",
+      "integrity": "sha512-jZzopQ5rKC3QcivZ9tBsYjPWB0+d5+lSO4tASIgAia30pyACCFaN2M1PKX/lwoGmB+oklHzSIMu+iNtLUyDl2A==",
       "peer": true,
       "requires": {
-        "@firebase/component": "0.5.9",
+        "@firebase/component": "0.5.10",
         "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.4.2",
+        "@firebase/util": "1.4.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -15739,15 +15713,15 @@
       }
     },
     "@firebase/app-compat": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.12.tgz",
-      "integrity": "sha512-hRzCCFjwTwrFsAFcuUW2TPpyShJ/OaoA1Yxp4QJr6Xod8g+CQxTMZ4RJ51I5t9fErXvl65VxljhfqFEyB3ZmJA==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.16.tgz",
+      "integrity": "sha512-PCGqanykO1H2jO3gzT0x7VxjZ0stBkF89VBqpOJfZ+srjSQgfWZuHjwbaVoq2Ayza1/s79iF0Eg7LSBx54TBSg==",
       "peer": true,
       "requires": {
-        "@firebase/app": "0.7.11",
-        "@firebase/component": "0.5.9",
+        "@firebase/app": "0.7.15",
+        "@firebase/component": "0.5.10",
         "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.4.2",
+        "@firebase/util": "1.4.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -15771,11 +15745,11 @@
       "requires": {}
     },
     "@firebase/component": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.9.tgz",
-      "integrity": "sha512-oLCY3x9WbM5rn06qmUvbtJuPj4dIw/C9T4Th52IiHF5tiCRC5k6YthvhfUVcTwfoUhK0fOgtwuKJKA/LpCPjgA==",
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.10.tgz",
+      "integrity": "sha512-mzUpg6rsBbdQJvAdu1rNWabU3O7qdd+B+/ubE1b+pTbBKfw5ySRpRRE6sKcZ/oQuwLh0HHB6FRJHcylmI7jDzA==",
       "requires": {
-        "@firebase/util": "1.4.2",
+        "@firebase/util": "1.4.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -15787,14 +15761,14 @@
       }
     },
     "@firebase/database": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.12.4.tgz",
-      "integrity": "sha512-XkrL1kXELRNkqKcltuT4hfG1gWmFiGvjFY+z7Lhb//12MqdkLjwa9YMK8c6Lo+Ro+IkWcJArQaOQYe3GkU5Wgg==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.12.5.tgz",
+      "integrity": "sha512-1Pd2jYqvqZI7SQWAiXbTZxmsOa29PyOaPiUtr8pkLSfLp4AeyMBegYAXCLYLW6BNhKn3zNKFkxYDxYHq4q+Ixg==",
       "requires": {
         "@firebase/auth-interop-types": "0.1.6",
-        "@firebase/component": "0.5.9",
+        "@firebase/component": "0.5.10",
         "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.4.2",
+        "@firebase/util": "1.4.3",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       },
@@ -15807,27 +15781,18 @@
       }
     },
     "@firebase/database-compat": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.1.4.tgz",
-      "integrity": "sha512-dIJiZLDFF3U+MoEwoPBy7zxWmBUro1KefmwSHlpOoxmPv76tuoPm85NumpW/HmMrtTcTkC2qowtb6NjGE8X7mw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.1.5.tgz",
+      "integrity": "sha512-UVxkHL24sZfsjsjs+yiKIdYdrWXHrLxSFCYNdwNXDlTkAc0CWP9AAY3feLhBVpUKk+4Cj0I4sGnyIm2C1ltAYg==",
       "requires": {
-        "@firebase/component": "0.5.9",
-        "@firebase/database": "0.12.4",
-        "@firebase/database-types": "0.9.3",
+        "@firebase/component": "0.5.10",
+        "@firebase/database": "0.12.5",
+        "@firebase/database-types": "0.9.4",
         "@firebase/logger": "0.3.2",
-        "@firebase/util": "1.4.2",
+        "@firebase/util": "1.4.3",
         "tslib": "^2.1.0"
       },
       "dependencies": {
-        "@firebase/database-types": {
-          "version": "0.9.3",
-          "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.3.tgz",
-          "integrity": "sha512-R+YXLWy/Q7mNUxiUYiMboTwvVoprrgfyvf1Viyevskw6IoH1q8HV1UjlkLSgmRsOT9HPWt7XZUEStVZJFknHwg==",
-          "requires": {
-            "@firebase/app-types": "0.7.0",
-            "@firebase/util": "1.4.2"
-          }
-        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -15836,18 +15801,12 @@
       }
     },
     "@firebase/database-types": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.7.3.tgz",
-      "integrity": "sha512-dSOJmhKQ0nL8O4EQMRNGpSExWCXeHtH57gGg0BfNAdWcKhC8/4Y+qfKLfWXzyHvrSecpLmO0SmAi/iK2D5fp5A==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.9.4.tgz",
+      "integrity": "sha512-uAQuc6NUZ5Oh/cWZPeMValtcZ+4L1stgKOeYvz7mLn8+s03tnCDL2N47OLCHdntktVkhImQTwGNARgqhIhtNeA==",
       "requires": {
-        "@firebase/app-types": "0.6.3"
-      },
-      "dependencies": {
-        "@firebase/app-types": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.3.tgz",
-          "integrity": "sha512-/M13DPPati7FQHEQ9Minjk1HGLm/4K4gs9bR4rzLCWJg64yGtVC0zNg9gDpkw9yc2cvol/mNFxqTtd4geGrwdw=="
-        }
+        "@firebase/app-types": "0.7.0",
+        "@firebase/util": "1.4.3"
       }
     },
     "@firebase/logger": {
@@ -15866,9 +15825,9 @@
       }
     },
     "@firebase/util": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.4.2.tgz",
-      "integrity": "sha512-JMiUo+9QE9lMBvEtBjqsOFdmJgObFvi7OL1A0uFGwTmlCI1ZeNPOEBrwXkgTOelVCdiMO15mAebtEyxFuQ6FsA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.4.3.tgz",
+      "integrity": "sha512-gQJl6r0a+MElLQEyU8Dx0kkC2coPj67f/zKZrGR7z7WpLgVanhaCUqEsptwpwoxi9RMFIaebleG+C9xxoARq+Q==",
       "requires": {
         "tslib": "^2.1.0"
       },
@@ -15928,38 +15887,35 @@
       "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA=="
     },
     "@google-cloud/storage": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.16.1.tgz",
-      "integrity": "sha512-C2li/2PUfLSGEetebLL70uQRwqm6PS+kBtFEjr5AnAn/Qv0UnD8V+rI9Y4RmwxWFvhlPAgg+ZRqa4bkK4eUxlA==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.18.1.tgz",
+      "integrity": "sha512-EeVIarDb6u9vE5Se3YaXA8tuW8Ae2xmYLHy43doutTwzkXwizGXVS2Qmc2pouq9ln8qMD9A2f3arvhgAPtK9LQ==",
       "optional": true,
       "requires": {
         "@google-cloud/common": "^3.8.1",
         "@google-cloud/paginator": "^3.0.0",
         "@google-cloud/promisify": "^2.0.0",
+        "abort-controller": "^3.0.0",
         "arrify": "^2.0.0",
-        "async-retry": "^1.3.1",
+        "async-retry": "^1.3.3",
         "compressible": "^2.0.12",
+        "configstore": "^5.0.0",
         "date-and-time": "^2.0.0",
         "duplexify": "^4.0.0",
         "extend": "^3.0.2",
-        "gcs-resumable-upload": "^3.6.0",
+        "gaxios": "^4.0.0",
         "get-stream": "^6.0.0",
+        "google-auth-library": "^7.0.0",
         "hash-stream-validation": "^0.2.2",
         "mime": "^3.0.0",
         "mime-types": "^2.0.8",
         "p-limit": "^3.0.1",
         "pumpify": "^2.0.0",
         "snakeize": "^0.1.0",
-        "stream-events": "^1.0.1",
+        "stream-events": "^1.0.4",
         "xdg-basedir": "^4.0.0"
       },
       "dependencies": {
-        "mime": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-          "optional": true
-        },
         "p-limit": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -16734,20 +16690,20 @@
       }
     },
     "@thatconference/api": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-2.5.0.tgz",
-      "integrity": "sha512-QS8/91FMxT71q9HJyvFRz1ItZsaU3Mpk9XFp14c3d3KQwnRdx50jCzi0/E2txXU6mywglwZCmN2Flh9Su7NbBQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-2.7.0.tgz",
+      "integrity": "sha512-mLmgyY/m5LwG+cUKssM9DwDlDU5V/6VR9jQ5Rr9uSRhodA2JWHCC3a3yyv6g2b+nV4yG0/rnVtHzSAKXSuta4g==",
       "requires": {
         "apollo-server": "2.22.2",
-        "auth0": "^2.37.0",
+        "auth0": "^2.38.1",
         "debug": "^4.3.3",
-        "firebase-admin": "^10.0.1",
+        "firebase-admin": "^10.0.2",
         "graphql": "^15.8.0",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.5",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "node-fetch": "^2.6.6",
+        "node-fetch": "^2.6.7",
         "request-ip": "^2.1.3",
         "yup": "^0.32.11"
       }
@@ -17685,17 +17641,16 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "auth0": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.37.0.tgz",
-      "integrity": "sha512-6Kz/+7d3PRb1zKR6O7CVt0EHAu+dphLFbJcvCEn7z9mUyjM0kJp/RnkALfFLfVzmSsaWeBqQNi2uZmdjReCjzQ==",
+      "version": "2.38.1",
+      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.38.1.tgz",
+      "integrity": "sha512-46PS8bQyEJs7OAdhFAJKrgjCblovTij4hO7Y3PPPY2e8AulO8fGrvKDiucBLm2phGc8d45bOF7z7wB3ilNSc+A==",
       "requires": {
-        "axios": "^0.21.4",
-        "es6-promisify": "^6.1.1",
+        "axios": "^0.24.0",
         "form-data": "^3.0.1",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^1.12.1",
         "lru-memoizer": "^2.1.4",
-        "rest-facade": "^1.13.1",
+        "rest-facade": "^1.16.3",
         "retry": "^0.13.1"
       },
       "dependencies": {
@@ -17714,16 +17669,26 @@
             "lru-memoizer": "^2.1.2",
             "ms": "^2.1.2",
             "proxy-from-env": "^1.1.0"
+          },
+          "dependencies": {
+            "axios": {
+              "version": "0.21.4",
+              "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+              "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+              "requires": {
+                "follow-redirects": "^1.14.0"
+              }
+            }
           }
         }
       }
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.4"
       }
     },
     "babel-eslint": {
@@ -18729,9 +18694,9 @@
       "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
     },
     "date-and-time": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-2.0.1.tgz",
-      "integrity": "sha512-O7Xe5dLaqvY/aF/MFWArsAM1J4j7w1CSZlPCX9uHgmb+6SbkPd8Q4YOvfvH/cZGvFlJFfHOZKxQtmMUOoZhc/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-2.1.0.tgz",
+      "integrity": "sha512-X/b2gM7e8zQ7siiE0DhRLeNMpuCkIqec5Jnx4GMk/HWB71a6e5Lz48mH9/GIS/hpLsBRFZfMF1gjXBkY0vq5oA==",
       "optional": true
     },
     "date-fns": {
@@ -19032,11 +18997,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promisify": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -19877,19 +19837,19 @@
       }
     },
     "firebase-admin": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.0.1.tgz",
-      "integrity": "sha512-p8nrhNJyuAj/Pc3M0TWVU8rd4rPoeCREfRt7dJ+EwkMvFCdJ6Cb21y3ZlN3Qsbok8PEQjuWLNy+C3LQMTfUOcQ==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-10.0.2.tgz",
+      "integrity": "sha512-MLH0SPmC4L0aCHvPjs1KThraru/T84T3hxiPY3uCH7NZEgE/T5n4GwecwU3RcM3X+br75BIBY7qhaR5uCxhdXA==",
       "requires": {
         "@firebase/database-compat": "^0.1.1",
-        "@firebase/database-types": "^0.7.2",
+        "@firebase/database-types": "^0.9.3",
         "@google-cloud/firestore": "^4.5.0",
         "@google-cloud/storage": "^5.3.0",
         "@types/node": ">=12.12.47",
         "dicer": "^0.3.0",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.2",
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.0.0"
       },
       "dependencies": {
         "@google-cloud/firestore": {
@@ -19923,9 +19883,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -20013,22 +19973,6 @@
       "requires": {
         "gaxios": "^4.0.0",
         "json-bigint": "^1.0.0"
-      }
-    },
-    "gcs-resumable-upload": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.6.0.tgz",
-      "integrity": "sha512-IyaNs4tx3Mp2UKn0CltRUiW/ZXYFlBNuK/V+ixs80chzVD+BJq3+8bfiganATFfCoMluAjokF9EswNJdVuOs8A==",
-      "optional": true,
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "async-retry": "^1.3.3",
-        "configstore": "^5.0.0",
-        "extend": "^3.0.2",
-        "gaxios": "^4.0.0",
-        "google-auth-library": "^7.0.0",
-        "pumpify": "^2.0.0",
-        "stream-events": "^1.0.4"
       }
     },
     "gensync": {
@@ -20166,11 +20110,11 @@
       }
     },
     "google-p12-pem": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.2.tgz",
-      "integrity": "sha512-tjf3IQIt7tWCDsa0ofDQ1qqSCNzahXDxdAGJDbruWqu3eCg5CKLYKN+hi0s6lfvzYZ1GDVr+oDF9OOWlDSdf0A==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.3.tgz",
+      "integrity": "sha512-MC0jISvzymxePDVembypNefkAQp+DRP7dBE+zNUPaIjEspIlYg0++OrsNr248V9tPbz6iqtZ7rX1hxWA5B8qBQ==",
       "requires": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.0.0"
       }
     },
     "got": {
@@ -22449,9 +22393,10 @@
       }
     },
     "mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "optional": true
     },
     "mime-db": {
       "version": "1.44.0",
@@ -22573,9 +22518,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
       },
@@ -22602,9 +22547,9 @@
       }
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -23023,16 +22968,6 @@
       "integrity": "sha512-0rpIqBQ9ey7MqLVBlEJAnnw8lbnANqgnwR/lrXEzzdH1RggmTP/zAdZB9OEzgILK+Uw2FpIVyJrnhMimfjWMRQ==",
       "requires": {
         "axios": "^0.24.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-          "requires": {
-            "follow-redirects": "^1.14.4"
-          }
-        }
       }
     },
     "prelude-ls": {
@@ -24572,10 +24507,15 @@
         "semver": "^7.3.2"
       },
       "dependencies": {
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
+        },
         "qs": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "version": "6.10.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
           "requires": {
             "side-channel": "^1.0.4"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-events",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "description": "THATConference.com events service",
   "main": "index.js",
   "engines": {
@@ -40,7 +40,7 @@
     "graphql-scalars": "^1.14.1",
     "graphql-type-json": "^0.3.2",
     "lodash": "^4.17.21",
-    "node-fetch": "^2.6.6",
+    "node-fetch": "^2.6.7",
     "postmark": "^2.8.1",
     "response-time": "^2.3.2",
     "slugify": "^1.6.5",

--- a/src/graphql/typeDefs/dataTypes/extendedTypes/extended-products.graphql
+++ b/src/graphql/typeDefs/dataTypes/extendedTypes/extended-products.graphql
@@ -9,30 +9,34 @@ union Product =
   | Training
   | Family
 
-extend type Ticket @key(fields: "id") {
+extend interface ProductBase @key(fields: "id") {
   id: ID! @external
 }
 
-extend type Membership @key(fields: "id") {
+extend type Ticket implements ProductBase @key(fields: "id") {
   id: ID! @external
 }
 
-extend type Partnership @key(fields: "id") {
+extend type Membership implements ProductBase @key(fields: "id") {
   id: ID! @external
 }
 
-extend type Food @key(fields: "id") {
+extend type Partnership implements ProductBase @key(fields: "id") {
   id: ID! @external
 }
 
-extend type Coupon @key(fields: "id") {
+extend type Food implements ProductBase @key(fields: "id") {
   id: ID! @external
 }
 
-extend type Training @key(fields: "id") {
+extend type Coupon implements ProductBase @key(fields: "id") {
   id: ID! @external
 }
 
-extend type Family @key(fields: "id") {
+extend type Training implements ProductBase @key(fields: "id") {
+  id: ID! @external
+}
+
+extend type Family implements ProductBase @key(fields: "id") {
   id: ID! @external
 }


### PR DESCRIPTION
v2.13.0
Interface ProductBase extended into Events and implemented on each extended type
The referenced error is caused by the Events api not knowing about interface type `ProductType` 
Added updated for High vulnerability in node-fetch.



Example returned error:
```json
{
	"errors": [
		{
			"message": "400: Bad Request",
			"extensions": {
				"code": "INTERNAL_SERVER_ERROR",
				"response": {
					"url": "https://events-bgydxslf5a-uc.a.run.app/",
					"status": 400,
					"statusText": "Bad Request",
					"body": {
						"errors": [
							{
								"message": "Unknown type \"ProductBase\". Did you mean \"ProductType\" or \"Product\"?",
								"locations": [
									{
										"line": 1,
										"column": 311
									}
								],
								"extensions": {
									"code": "GRAPHQL_VALIDATION_FAILED"
								}
							}
						]
					}
				}
			}
		}
	],
	"data": {
		"events": null
	}
}
```