### PR TITLE
update eventAdmin to expose eventId for federation use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "@google-cloud/trace-agent": "^5.1.6",
         "@graphql-tools/load-files": "6.2.7",
         "@graphql-tools/merge": "6.2.10",
-        "@sentry/node": "^6.17.9",
-        "@thatconference/api": "^2.8.2",
+        "@sentry/node": "^6.18.0",
+        "@thatconference/api": "^2.8.3",
         "@thatconference/schema": "^1.5.0",
         "apollo-server-express": "2.22.2",
         "dataloader": "^2.0.0",
@@ -3006,14 +3006,14 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@sentry/core": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.17.9.tgz",
-      "integrity": "sha512-14KalmTholGUtgdh9TklO+jUpyQ/D3OGkhlH1rnGQGoJgFy2eYm+s+MnUEMxFdGIUCz5kOteuNqYZxaDmFagpQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.18.0.tgz",
+      "integrity": "sha512-I3iQVfMWHXR/LtevJg83aD7UAiUBLz1xAW8y3gd5lJej96UNv/4TbCmKZumYnEJMXf8EcFlg8t48W0Bl1GxhEg==",
       "dependencies": {
-        "@sentry/hub": "6.17.9",
-        "@sentry/minimal": "6.17.9",
-        "@sentry/types": "6.17.9",
-        "@sentry/utils": "6.17.9",
+        "@sentry/hub": "6.18.0",
+        "@sentry/minimal": "6.18.0",
+        "@sentry/types": "6.18.0",
+        "@sentry/utils": "6.18.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3026,12 +3026,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/hub": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.17.9.tgz",
-      "integrity": "sha512-34EdrweWDbBV9EzEFIXcO+JeoyQmKzQVJxpTKZoJA6PUwf2NrndaUdjlkDEtBEzjuLUTxhLxtOzEsYs1O6RVcg==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.18.0.tgz",
+      "integrity": "sha512-E2GrrNcidyT67ONU3btHO5vyS1bPQNdWqC09sUc1F3q/nQyvc7L2W09TKY2veaMZQtC9EU760fTG1hMmgGwPmw==",
       "dependencies": {
-        "@sentry/types": "6.17.9",
-        "@sentry/utils": "6.17.9",
+        "@sentry/types": "6.18.0",
+        "@sentry/utils": "6.18.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3044,12 +3044,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.17.9.tgz",
-      "integrity": "sha512-T3PMCHcKk6lkZq6zKgANrYJJxXBXKOe+ousV1Fas1rVBMv7dtKfsa4itqQHszcW9shusPDiaQKIJ4zRLE5LKmg==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.18.0.tgz",
+      "integrity": "sha512-QkkWOhX3NMycUNLj96thMQ0BclmfxE2VdDf9ZqRkvdFzxI1FVY5NEArqD4wtlrCIoYN1ioAYrvdb48/BTuGung==",
       "dependencies": {
-        "@sentry/hub": "6.17.9",
-        "@sentry/types": "6.17.9",
+        "@sentry/hub": "6.18.0",
+        "@sentry/types": "6.18.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3062,15 +3062,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/node": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.17.9.tgz",
-      "integrity": "sha512-jbn+q7qPGOh6D7nYoYGaAlmuvMDpQmyMwBtUVYybuZp2AALe43O3Z4LtoJ+1+F31XowpsIPZx1mwNs4ZrILskA==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.18.0.tgz",
+      "integrity": "sha512-gESzabgJSs3uuOpZQ4tdI3V0k1nl9fqToTHOJDMeOqusHYfY/wlRDtdvN0Qn+vdvkGI/Eh3u8RnFQXCzkbCAbQ==",
       "dependencies": {
-        "@sentry/core": "6.17.9",
-        "@sentry/hub": "6.17.9",
-        "@sentry/tracing": "6.17.9",
-        "@sentry/types": "6.17.9",
-        "@sentry/utils": "6.17.9",
+        "@sentry/core": "6.18.0",
+        "@sentry/hub": "6.18.0",
+        "@sentry/tracing": "6.18.0",
+        "@sentry/types": "6.18.0",
+        "@sentry/utils": "6.18.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -3086,14 +3086,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/tracing": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.17.9.tgz",
-      "integrity": "sha512-5Rb/OS4ryNJLvz2nv6wyjwhifjy6veqaF9ffLrwFYij/WDy7m62ASBblxgeiI3fbPLX0aBRFWIJAq1vko26+AQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.18.0.tgz",
+      "integrity": "sha512-thwVrYT+ba58h6F6Im4t+JH9o+7H+75ribkeTgM7NRhNuiGajlXNmb37Dh9gP5Iy76jNV8GATy4cOcuVc7P1jA==",
       "dependencies": {
-        "@sentry/hub": "6.17.9",
-        "@sentry/minimal": "6.17.9",
-        "@sentry/types": "6.17.9",
-        "@sentry/utils": "6.17.9",
+        "@sentry/hub": "6.18.0",
+        "@sentry/minimal": "6.18.0",
+        "@sentry/types": "6.18.0",
+        "@sentry/utils": "6.18.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3106,19 +3106,19 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/types": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.17.9.tgz",
-      "integrity": "sha512-xuulX6qUCL14ayEOh/h6FUIvZtsi1Bx34dSOaWDrjXUOJHJAM7214uiqW1GZxPJ13YuaUIubjTSfDmSQ9CBzTw==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.0.tgz",
+      "integrity": "sha512-SypDwXL1URE/XLkP4Ve+pFs41e+2OUYZ0lCimNreQQv46//pFXxP3LwU9Tc0Az4ZfxXnGiwofvt73XyBq9VpRQ==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.17.9.tgz",
-      "integrity": "sha512-4eo9Z3JlJCGlGrQRbtZWL+L9NnlUXgTbfK3Lk7oO8D1ev8R5b5+iE6tZHTvU5rQRcq6zu+POT+tK5u9oxc/rnQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.18.0.tgz",
+      "integrity": "sha512-mKegOabkAjoUHfokjI5oi3CMez5GD3xXOrBFcLVc9GFDXCgNMdYnHyEn/mmy8PikFdGHxZ3oI/16ZGU22wi5aw==",
       "dependencies": {
-        "@sentry/types": "6.17.9",
+        "@sentry/types": "6.18.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3170,12 +3170,12 @@
       }
     },
     "node_modules/@thatconference/api": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-2.8.2.tgz",
-      "integrity": "sha512-UKZLvCDfY1uzNavWTziHzz6KU3jBmIjsJ8vwNli3QTY2tK60wOasr3ZLtyMna55gRn5W0e+Dlfj6uckFiLQSaw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-2.8.3.tgz",
+      "integrity": "sha512-5GwZVdrcx+pKUN/kxlJIzHdXgoWYctZe2DrqS0HAqvNWtO4g6qDg98vZlpHMeAcvouWrr7YlO6dBROogjtjLhQ==",
       "dependencies": {
         "apollo-server": "2.22.2",
-        "auth0": "^2.39.0",
+        "auth0": "^2.40.0",
         "debug": "^4.3.3",
         "firebase-admin": "^10.0.2",
         "graphql": "^15.8.0",
@@ -16564,14 +16564,14 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@sentry/core": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.17.9.tgz",
-      "integrity": "sha512-14KalmTholGUtgdh9TklO+jUpyQ/D3OGkhlH1rnGQGoJgFy2eYm+s+MnUEMxFdGIUCz5kOteuNqYZxaDmFagpQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.18.0.tgz",
+      "integrity": "sha512-I3iQVfMWHXR/LtevJg83aD7UAiUBLz1xAW8y3gd5lJej96UNv/4TbCmKZumYnEJMXf8EcFlg8t48W0Bl1GxhEg==",
       "requires": {
-        "@sentry/hub": "6.17.9",
-        "@sentry/minimal": "6.17.9",
-        "@sentry/types": "6.17.9",
-        "@sentry/utils": "6.17.9",
+        "@sentry/hub": "6.18.0",
+        "@sentry/minimal": "6.18.0",
+        "@sentry/types": "6.18.0",
+        "@sentry/utils": "6.18.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -16583,12 +16583,12 @@
       }
     },
     "@sentry/hub": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.17.9.tgz",
-      "integrity": "sha512-34EdrweWDbBV9EzEFIXcO+JeoyQmKzQVJxpTKZoJA6PUwf2NrndaUdjlkDEtBEzjuLUTxhLxtOzEsYs1O6RVcg==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.18.0.tgz",
+      "integrity": "sha512-E2GrrNcidyT67ONU3btHO5vyS1bPQNdWqC09sUc1F3q/nQyvc7L2W09TKY2veaMZQtC9EU760fTG1hMmgGwPmw==",
       "requires": {
-        "@sentry/types": "6.17.9",
-        "@sentry/utils": "6.17.9",
+        "@sentry/types": "6.18.0",
+        "@sentry/utils": "6.18.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -16600,12 +16600,12 @@
       }
     },
     "@sentry/minimal": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.17.9.tgz",
-      "integrity": "sha512-T3PMCHcKk6lkZq6zKgANrYJJxXBXKOe+ousV1Fas1rVBMv7dtKfsa4itqQHszcW9shusPDiaQKIJ4zRLE5LKmg==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.18.0.tgz",
+      "integrity": "sha512-QkkWOhX3NMycUNLj96thMQ0BclmfxE2VdDf9ZqRkvdFzxI1FVY5NEArqD4wtlrCIoYN1ioAYrvdb48/BTuGung==",
       "requires": {
-        "@sentry/hub": "6.17.9",
-        "@sentry/types": "6.17.9",
+        "@sentry/hub": "6.18.0",
+        "@sentry/types": "6.18.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -16617,15 +16617,15 @@
       }
     },
     "@sentry/node": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.17.9.tgz",
-      "integrity": "sha512-jbn+q7qPGOh6D7nYoYGaAlmuvMDpQmyMwBtUVYybuZp2AALe43O3Z4LtoJ+1+F31XowpsIPZx1mwNs4ZrILskA==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.18.0.tgz",
+      "integrity": "sha512-gESzabgJSs3uuOpZQ4tdI3V0k1nl9fqToTHOJDMeOqusHYfY/wlRDtdvN0Qn+vdvkGI/Eh3u8RnFQXCzkbCAbQ==",
       "requires": {
-        "@sentry/core": "6.17.9",
-        "@sentry/hub": "6.17.9",
-        "@sentry/tracing": "6.17.9",
-        "@sentry/types": "6.17.9",
-        "@sentry/utils": "6.17.9",
+        "@sentry/core": "6.18.0",
+        "@sentry/hub": "6.18.0",
+        "@sentry/tracing": "6.18.0",
+        "@sentry/types": "6.18.0",
+        "@sentry/utils": "6.18.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -16640,14 +16640,14 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.17.9.tgz",
-      "integrity": "sha512-5Rb/OS4ryNJLvz2nv6wyjwhifjy6veqaF9ffLrwFYij/WDy7m62ASBblxgeiI3fbPLX0aBRFWIJAq1vko26+AQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.18.0.tgz",
+      "integrity": "sha512-thwVrYT+ba58h6F6Im4t+JH9o+7H+75ribkeTgM7NRhNuiGajlXNmb37Dh9gP5Iy76jNV8GATy4cOcuVc7P1jA==",
       "requires": {
-        "@sentry/hub": "6.17.9",
-        "@sentry/minimal": "6.17.9",
-        "@sentry/types": "6.17.9",
-        "@sentry/utils": "6.17.9",
+        "@sentry/hub": "6.18.0",
+        "@sentry/minimal": "6.18.0",
+        "@sentry/types": "6.18.0",
+        "@sentry/utils": "6.18.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -16659,16 +16659,16 @@
       }
     },
     "@sentry/types": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.17.9.tgz",
-      "integrity": "sha512-xuulX6qUCL14ayEOh/h6FUIvZtsi1Bx34dSOaWDrjXUOJHJAM7214uiqW1GZxPJ13YuaUIubjTSfDmSQ9CBzTw=="
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.18.0.tgz",
+      "integrity": "sha512-SypDwXL1URE/XLkP4Ve+pFs41e+2OUYZ0lCimNreQQv46//pFXxP3LwU9Tc0Az4ZfxXnGiwofvt73XyBq9VpRQ=="
     },
     "@sentry/utils": {
-      "version": "6.17.9",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.17.9.tgz",
-      "integrity": "sha512-4eo9Z3JlJCGlGrQRbtZWL+L9NnlUXgTbfK3Lk7oO8D1ev8R5b5+iE6tZHTvU5rQRcq6zu+POT+tK5u9oxc/rnQ==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.18.0.tgz",
+      "integrity": "sha512-mKegOabkAjoUHfokjI5oi3CMez5GD3xXOrBFcLVc9GFDXCgNMdYnHyEn/mmy8PikFdGHxZ3oI/16ZGU22wi5aw==",
       "requires": {
-        "@sentry/types": "6.17.9",
+        "@sentry/types": "6.18.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -16713,12 +16713,12 @@
       }
     },
     "@thatconference/api": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-2.8.2.tgz",
-      "integrity": "sha512-UKZLvCDfY1uzNavWTziHzz6KU3jBmIjsJ8vwNli3QTY2tK60wOasr3ZLtyMna55gRn5W0e+Dlfj6uckFiLQSaw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/@thatconference/api/-/api-2.8.3.tgz",
+      "integrity": "sha512-5GwZVdrcx+pKUN/kxlJIzHdXgoWYctZe2DrqS0HAqvNWtO4g6qDg98vZlpHMeAcvouWrr7YlO6dBROogjtjLhQ==",
       "requires": {
         "apollo-server": "2.22.2",
-        "auth0": "^2.39.0",
+        "auth0": "^2.40.0",
         "debug": "^4.3.3",
         "firebase-admin": "^10.0.2",
         "graphql": "^15.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-events",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "THATConference.com events service",
   "main": "index.js",
   "engines": {
@@ -26,8 +26,8 @@
     "@google-cloud/trace-agent": "^5.1.6",
     "@graphql-tools/load-files": "6.2.7",
     "@graphql-tools/merge": "6.2.10",
-    "@sentry/node": "^6.17.9",
-    "@thatconference/api": "^2.8.2",
+    "@sentry/node": "^6.18.0",
+    "@thatconference/api": "^2.8.3",
     "@thatconference/schema": "^1.5.0",
     "apollo-server-express": "2.22.2",
     "dataloader": "^2.0.0",

--- a/src/graphql/typeDefs/queries/eventAdmin.graphql
+++ b/src/graphql/typeDefs/queries/eventAdmin.graphql
@@ -1,4 +1,6 @@
-type EventAdminQuery {
+type EventAdminQuery @key(fields: "eventId") {
+  eventId: ID!
+
   """
   Leave options blank for no filtering for those fields
   All accepted speakers for this event (from accepted speaker sub-collection)


### PR DESCRIPTION
v2.16.0
update eventAdmin to expose eventId for federation use
package bumps

NOTE: This pr to be updated prior to Garage update which extends `EventAdmin` type: thatconference/that-api-garage#82