### PR TITLE
send enrollment email on completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-events",
-  "version": "2.19.1",
+  "version": "2.20.0",
   "description": "THATConference.com events service",
   "main": "index.js",
   "engines": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,4 +4,9 @@ const constants = {
   ...apiConstants,
 };
 
+constants.THAT.USER_EVENTS = {
+  REGISTRATION_CHECKIN: 'registrationCheckIn',
+  SPEAKER_ENROLLMENT_COMPLETE: 'speakerEnrollmentComplete',
+};
+
 export default constants;

--- a/src/dataSources/cloudFirestore/order.js
+++ b/src/dataSources/cloudFirestore/order.js
@@ -123,8 +123,7 @@ const order = dbInstance => {
         Sentry.captureException(new Error(msg));
       });
 
-      // For now return true until it is determined this leave things in a bad state
-      return true;
+      return false;
     }
 
     const scrubbedOa = scrubOrderAllocation({

--- a/src/events/user.js
+++ b/src/events/user.js
@@ -13,7 +13,7 @@ function userEvents(postmark) {
   const userEventEmitter = new EventEmitter();
   dlog('user event emitter created');
 
-  async function getMemberInfo({ memberId, firestore }) {
+  async function getMemberInfo({ memberId, firestore, caller }) {
     dlog('fetching member info for %s', memberId);
     let member = null;
     try {
@@ -27,11 +27,11 @@ function userEvents(postmark) {
         scope.setLevel(Sentry.Severity.Warning);
         scope.setTags({
           event: 'user',
-          emit: constants.THAT.USER_EVENTS.REGISTRATION_CHECKIN,
+          caller,
           eventMemberId: memberId,
         });
         scope.setContext('member', member);
-        Sentry.captureMessage(`Unable to send welcome email, member not found`);
+        Sentry.captureMessage(`Unable to send email, member not found`);
       });
       return undefined;
     }
@@ -48,7 +48,11 @@ function userEvents(postmark) {
     dlog('sendCheckinWelcomeEmail called for %s', memberId);
     // may be an unallocated ticket and doesn't have a memberId assigned
     if (!memberId) return undefined;
-    const member = await getMemberInfo({ memberId, firestore });
+    const member = await getMemberInfo({
+      memberId,
+      firestore,
+      caller: 'sendCheckinWelcomeEmail',
+    });
     if (!member) return undefined;
 
     return postmark.sendEmailWithTemplate({
@@ -81,7 +85,11 @@ function userEvents(postmark) {
     );
 
     if (!memberId) return undefined;
-    const member = await getMemberInfo({ memberId, firestore });
+    const member = await getMemberInfo({
+      memberId,
+      firestore,
+      caller: 'sendSpeakerEnrollmentCompleteEmail',
+    });
     if (!member) return undefined;
 
     let templateAlias = 'speaker-enroll-complete-agree-true';

--- a/src/events/user.js
+++ b/src/events/user.js
@@ -4,6 +4,7 @@ import { dataSources } from '@thatconference/api';
 import * as Sentry from '@sentry/node';
 import envConfig from '../envConfig';
 import { SendEmailError } from '../lib/errors';
+import constants from '../constants';
 
 const dlog = debug('that:api:sessions:events:user');
 const memberStore = dataSources.cloudFirestore.member;
@@ -12,15 +13,8 @@ function userEvents(postmark) {
   const userEventEmitter = new EventEmitter();
   dlog('user event emitter created');
 
-  async function sendCheckinWelcomeEmail({
-    memberId,
-    firestore,
-    partnerPin,
-    eventSlug,
-  }) {
-    dlog('sendCheckinWelcomeEmail called for %s', memberId);
-    // may be an unallocated ticket and doesn't have a memberId assigned
-    if (!memberId) return undefined;
+  async function getMemberInfo({ memberId, firestore }) {
+    dlog('fetching member info for %s', memberId);
     let member = null;
     try {
       member = await memberStore(firestore).get(memberId);
@@ -33,7 +27,7 @@ function userEvents(postmark) {
         scope.setLevel(Sentry.Severity.Warning);
         scope.setTags({
           event: 'user',
-          emit: 'registrationCheckIn',
+          emit: constants.THAT.USER_EVENTS.REGISTRATION_CHECKIN,
           eventMemberId: memberId,
         });
         scope.setContext('member', member);
@@ -41,6 +35,21 @@ function userEvents(postmark) {
       });
       return undefined;
     }
+
+    return member;
+  }
+
+  async function sendCheckinWelcomeEmail({
+    memberId,
+    firestore,
+    partnerPin,
+    eventSlug,
+  }) {
+    dlog('sendCheckinWelcomeEmail called for %s', memberId);
+    // may be an unallocated ticket and doesn't have a memberId assigned
+    if (!memberId) return undefined;
+    const member = await getMemberInfo({ memberId, firestore });
+    if (!member) return undefined;
 
     return postmark.sendEmailWithTemplate({
       templateAlias: 'welcome-registration-checkin',
@@ -60,11 +69,52 @@ function userEvents(postmark) {
     });
   }
 
+  async function sendSpeakerEnrollmentCompleteEmail({
+    memberId,
+    agreeToSpeak,
+    firestore,
+  }) {
+    dlog(
+      'sendSpeakerEnrollmentCompleteEmail called for %s who agreeToSpeak $s',
+      memberId,
+      agreeToSpeak,
+    );
+
+    if (!memberId) return undefined;
+    const member = await getMemberInfo({ memberId, firestore });
+    if (!member) return undefined;
+
+    let templateAlias = 'speaker-enroll-complete-agree-true';
+    if (agreeToSpeak === false)
+      templateAlias = 'speaker-enroll-complete-agree-false';
+
+    return postmark.sendEmailWithTemplate({
+      templateAlias,
+      from: envConfig.notificationEmailFrom,
+      to: member.email,
+      templateModel: {
+        member: {
+          firstName: member.firstName,
+          lastName: member.lastName,
+        },
+      },
+      tag: 'speaker_enrollment_complete',
+    });
+  }
+
   userEventEmitter.on('emailError', err => {
-    throw new SendEmailError(err.message);
+    Sentry.setTag('section', 'userEventEmitter');
+    Sentry.captureException(new SendEmailError(err.message));
   });
 
-  userEventEmitter.on('registrationCheckIn', sendCheckinWelcomeEmail);
+  userEventEmitter.on(
+    constants.THAT.USER_EVENTS.REGISTRATION_CHECKIN,
+    sendCheckinWelcomeEmail,
+  );
+  userEventEmitter.on(
+    constants.THAT.USER_EVENTS.SPEAKER_ENROLLMENT_COMPLETE,
+    sendSpeakerEnrollmentCompleteEmail,
+  );
 
   return userEventEmitter;
 }

--- a/src/graphql/resolvers/mutations/registration.js
+++ b/src/graphql/resolvers/mutations/registration.js
@@ -1,8 +1,8 @@
 import debug from 'debug';
-import { constants } from '@thatconference/api';
 import { RegistrationError } from '../../../lib/errors';
 import orderStore from '../../../dataSources/cloudFirestore/order';
 import eventStore from '../../../dataSources/cloudFirestore/event';
+import constants from '../../../constants';
 
 const dlog = debug('that:api:events:mutations:registration');
 
@@ -97,7 +97,7 @@ export const fieldResolvers = {
           userId: user.sub,
         })
         .then(() => {
-          userEvents.emit('registrationCheckIn', {
+          userEvents.emit(constants.THAT.USER_EVENTS.REGISTRATION_CHECKIN, {
             firestore,
             memberId: allocation.allocatedTo || null,
             partnerPin,


### PR DESCRIPTION
v2.20.0
Send an email on Speaker Enrollment Completion
Send an email on Speaker not accept engagement
refactor event names to constants
New Postmark template alias names:
- `speaker-enroll-complete-agree-true`
- `speaker-enroll-complete-agree-false`
