### PR TITLE
reduce selected fields in query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-events",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "THATConference.com events service",
   "main": "index.js",
   "engines": {

--- a/src/dataSources/cloudFirestore/order.js
+++ b/src/dataSources/cloudFirestore/order.js
@@ -69,6 +69,7 @@ const order = dbInstance => {
     return orderCollection
       .where('event', '==', eventId)
       .where('status', '==', 'COMPLETE')
+      .select()
       .get()
       .then(querySnapshot => querySnapshot.docs.map(o => ({ id: o.id })));
   }


### PR DESCRIPTION
Reduces the bandwidth requirement of request by only returning I'ds which is all required to send to gateway. 

Moving order and orderAllcation calls only to garage would be a future enhancement to build upon this. 