### PR TITLE
add secret as passed-in value

### DIFF
--- a/.github/workflows/ci_onPushMain.yml
+++ b/.github/workflows/ci_onPushMain.yml
@@ -37,6 +37,7 @@ jobs:
       GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       SLACK_WEBHOOK_DEV_NOTIFICATIONS: ${{ secrets.SLACK_WEBHOOK_DEV_NOTIFICATIONS }}
+      STELLATE_TOKEN: ${{ secrets.STELLATE_TOKEN }}
 
   notifications:
     name: Workflow notifications

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-events",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "THAT events service",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
v3.0.1
fixes deployment in `redeploy-gateway` section

depends on pr thatconference/that-gh-actions#16