### PR TITLE
Adds new OrderType enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-events",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "THAT events service",
   "main": "index.js",
   "engines": {

--- a/src/graphql/typeDefs/dataTypes/enums/orderType.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/orderType.graphql
@@ -5,4 +5,6 @@ enum OrderType {
   SPEAKER
   "Partner order"
   PARTNER
+  "Claimable product order"
+  CLAIMABLE
 }


### PR DESCRIPTION
v3.1.0
depends on thatconference/that-api-garage#98
Add Order Type Enum
Enum is also defined in `that-api-garage`
These two api's must be deployed at the same time as until both are up and running the graph will not be valid (due to an enum mismatch between subgraphs).